### PR TITLE
Update KLAY asset mapping to 'klay-token' in Binance JSON files

### DIFF
--- a/csvs/binance-convert.json
+++ b/csvs/binance-convert.json
@@ -119,7 +119,7 @@
   "symbolAssetMap": {
     "COCOS": "crypto/cocos-bcx",
     "KAIA": "crypto/kaia",
-    "KLAY": "crypto/klaytn",
+    "KLAY": "crypto/klay-token",
     "RNDR": "crypto/render-token",
     "TOMO": "crypto/tomochain"
   }

--- a/csvs/binance-spot-trade.json
+++ b/csvs/binance-spot-trade.json
@@ -237,7 +237,7 @@
   "symbolAssetMap": {
     "COCOS": "crypto/cocos-bcx",
     "KAIA": "crypto/kaia",
-    "KLAY": "crypto/klaytn",
+    "KLAY": "crypto/klay-token",
     "RNDR": "crypto/render-token",
     "TOMO": "crypto/tomochain"
   }

--- a/csvs/binance-transaction-record.json
+++ b/csvs/binance-transaction-record.json
@@ -682,7 +682,7 @@
   "symbolAssetMap": {
     "COCOS": "crypto/cocos-bcx",
     "KAIA": "crypto/kaia",
-    "KLAY": "crypto/klaytn",
+    "KLAY": "crypto/klay-token",
     "RNDR": "crypto/render-token",
     "TOMO": "crypto/tomochain"
   }

--- a/csvs/binance-withdraw-2.json
+++ b/csvs/binance-withdraw-2.json
@@ -226,7 +226,7 @@
   "symbolAssetMap": {
     "COCOS": "crypto/cocos-bcx",
     "KAIA": "crypto/kaia",
-    "KLAY": "crypto/klaytn",
+    "KLAY": "crypto/klay-token",
     "RNDR": "crypto/render-token",
     "TOMO": "crypto/tomochain"
   }

--- a/csvs/binance-withdraw.json
+++ b/csvs/binance-withdraw.json
@@ -166,7 +166,7 @@
   "symbolAssetMap": {
     "COCOS": "crypto/cocos-bcx",
     "KAIA": "crypto/kaia",
-    "KLAY": "crypto/klaytn",
+    "KLAY": "crypto/klay-token",
     "RNDR": "crypto/render-token",
     "TOMO": "crypto/tomochain"
   }

--- a/csvs/binance-withdrawal-ja.json
+++ b/csvs/binance-withdrawal-ja.json
@@ -226,7 +226,7 @@
   "symbolAssetMap": {
     "COCOS": "crypto/cocos-bcx",
     "KAIA": "crypto/kaia",
-    "KLAY": "crypto/klaytn",
+    "KLAY": "crypto/klay-token",
     "RNDR": "crypto/render-token",
     "TOMO": "crypto/tomochain"
   }


### PR DESCRIPTION
Change the asset mapping for KLAY to use 'klay-token' instead of 'klaytn' in multiple JSON files.