### PR TITLE
Add asset mapping for 'JOC' in JSON files

### DIFF
--- a/csvs/gate-future-action.json
+++ b/csvs/gate-future-action.json
@@ -446,6 +446,7 @@
     "EVADORE": "crypto/evadore",
     "EVADORE_OLD": "crypto/evadore",
     "F": "crypto/synfutures",
+    "JOC": "crypto/japan-open-chain",
     "MEME": "crypto/memecoin-2",
     "MEMETOON": "crypto/memetoon",
     "MYRO": "crypto/myro",

--- a/csvs/gate-spot-action.json
+++ b/csvs/gate-spot-action.json
@@ -972,6 +972,7 @@
     "EVADORE": "crypto/evadore",
     "EVADORE_OLD": "crypto/evadore",
     "F": "crypto/synfutures",
+    "JOC": "crypto/japan-open-chain",
     "MEME": "crypto/memecoin-2",
     "MEMEBRC": "crypto/meme-brc-20",
     "MEMETOON": "crypto/memetoon",

--- a/csvs/gate-spot-trade-2.json
+++ b/csvs/gate-spot-trade-2.json
@@ -225,6 +225,7 @@
     "EVADORE": "crypto/evadore",
     "EVADORE_OLD": "crypto/evadore",
     "F": "crypto/synfutures",
+    "JOC": "crypto/japan-open-chain",
     "MEME": "crypto/memecoin-2",
     "MEMEBRC": "crypto/meme-brc-20",
     "MEMETOON": "crypto/memetoon",

--- a/csvs/gate-spot-trade.json
+++ b/csvs/gate-spot-trade.json
@@ -245,6 +245,7 @@
     "EVADORE": "crypto/evadore",
     "EVADORE_OLD": "crypto/evadore",
     "F": "crypto/synfutures",
+    "JOC": "crypto/japan-open-chain",
     "MEME": "crypto/memecoin-2",
     "MEMEBRC": "crypto/meme-brc-20",
     "MEMETOON": "crypto/memetoon",

--- a/csvs/gate-withdrawal.json
+++ b/csvs/gate-withdrawal.json
@@ -157,6 +157,7 @@
     "EVADORE": "crypto/evadore",
     "EVADORE_OLD": "crypto/evadore",
     "F": "crypto/synfutures",
+    "JOC": "crypto/japan-open-chain",
     "MEME": "crypto/memecoin-2",
     "MEMEBRC": "crypto/meme-brc-20",
     "MEMETOON": "crypto/memetoon",

--- a/csvs/mexc-future-flow-ja-jst.json
+++ b/csvs/mexc-future-flow-ja-jst.json
@@ -197,6 +197,7 @@
     "ASMATCH": "crypto/asmatch",
     "COM": "crypto/com-ordinals",
     "EVADORE": "crypto/evadore",
+    "JOC": "crypto/japan-open-chain",
     "MEME": "crypto/memecoin-2",
     "MEMETOON": "crypto/memetoon",
     "PIG": "crypto/pig-finance",

--- a/csvs/mexc-future-ja-jst.json
+++ b/csvs/mexc-future-ja-jst.json
@@ -274,6 +274,7 @@
     "ASMATCH": "crypto/asmatch",
     "COM": "crypto/com-ordinals",
     "EVADORE": "crypto/evadore",
+    "JOC": "crypto/japan-open-chain",
     "MEME": "crypto/memecoin-2",
     "MEMETOON": "crypto/memetoon",
     "PIG": "crypto/pig-finance",

--- a/csvs/mexc-spot-trade.json
+++ b/csvs/mexc-spot-trade.json
@@ -239,6 +239,7 @@
     "ASMATCH": "crypto/asmatch",
     "COM": "crypto/com-ordinals",
     "EVADORE": "crypto/evadore",
+    "JOC": "crypto/japan-open-chain",
     "MEME": "crypto/memecoin-2",
     "MEMETOON": "crypto/memetoon",
     "PIG": "crypto/pig-finance",

--- a/csvs/mexc-withdrawal-ja.json
+++ b/csvs/mexc-withdrawal-ja.json
@@ -98,6 +98,7 @@
     "ASMATCH": "crypto/asmatch",
     "COM": "crypto/com-ordinals",
     "EVADORE": "crypto/evadore",
+    "JOC": "crypto/japan-open-chain",
     "MEME": "crypto/memecoin-2",
     "MEMETOON": "crypto/memetoon",
     "PIG": "crypto/pig-finance",


### PR DESCRIPTION
Introduce a new asset mapping for 'JOC' associated with 'crypto/japan-open-chain' across multiple JSON files.