### PR TITLE
Update Bitget future trade CSV formats

### DIFF
--- a/csvs/bitget-future-trade-202412.json
+++ b/csvs/bitget-future-trade-202412.json
@@ -572,15 +572,8 @@
               "column": "Type"
             },
             "pattern": {
-              "type": "in",
-              "values": [
-                "trans_from_exchange",
-                "trans_to_exchange",
-                "trans_from_otc",
-                "trans_to_otc",
-                "trans_from_contract",
-                "trans_to_contract"
-              ]
+              "type": "reg-exp",
+              "pattern": "^trans_(from|to)_.*$"
             }
           }
         ],

--- a/csvs/bitget-future-trade.json
+++ b/csvs/bitget-future-trade.json
@@ -572,15 +572,8 @@
               "column": "type"
             },
             "pattern": {
-              "type": "in",
-              "values": [
-                "trans_from_exchange",
-                "trans_to_exchange",
-                "trans_from_otc",
-                "trans_to_otc",
-                "trans_from_contract",
-                "trans_to_contract"
-              ]
+              "type": "reg-exp",
+              "pattern": "^trans_(from|to)_.*$"
             }
           }
         ],


### PR DESCRIPTION
Revise the CSV format for Bitget future trades to use a regular expression for transaction types instead of a fixed list.