### PR TITLE
Update symbols

### DIFF
--- a/symbols/binance.json
+++ b/symbols/binance.json
@@ -108,6 +108,7 @@
   "BNX": "crypto/binaryx",
   "BOME": "crypto/book-of-meme",
   "BONK": "crypto/bonk",
+  "BOT": "crypto/0xtorch-binance-bot",
   "BRL": "crypto/0xtorch-binance-brl",
   "BROCCOLI714": "crypto/czs-dog",
   "BSW": "crypto/biswap",

--- a/symbols/mercatox.json
+++ b/symbols/mercatox.json
@@ -1,1 +1,3 @@
-{}
+{
+  "SCC": "crypto/0xtorch-mercatox-scc"
+}

--- a/symbols/mexc.json
+++ b/symbols/mexc.json
@@ -4286,7 +4286,7 @@
   "MATEAI": "crypto/0xtorch-mexc-mateai",
   "MATES": "crypto/0xtorch-mexc-mates",
   "MATH": "crypto/math",
-  "MATIC": "crypto/0xtorch-mexc-matic",
+  "MATIC": "crypto/polygon-ecosystem-token",
   "MATOLD": "crypto/0xtorch-mexc-matold",
   "MATRIX": "crypto/matrix-one",
   "MATTER": "crypto/0xtorch-mexc-matter",


### PR DESCRIPTION
https://discord.com/channels/1317710551245393951/1348647341095260324/1418157987918254163

取引所:Binance
Symbol:BOT
誤id:hyperbot
正id:evm_56_0x48dc0190df5ece990c649a7a07ba19d3650a9572

CoinGecko 未対応のため "crypto/0xtorch-binance-bot"

取引所:Mercatox
Symbol:SCC
誤id:stakecube
正id:evm_1_0x74fd51a98a4a1ecbef8cc43be801cce630e260bd

CoinGecko 未対応のため "crypto/0xtorch-mercatox-scc"

取引所:MEXC
Symbol:MATIC
誤id:0xtorch-mexc-matic
正id:polygon-ecosystem-token

"MATIC": "crypto/polygon-ecosystem-token" に更新

取引所:MEXC
Symbol:PCH
誤id:0xtorch-mexc-pch
正id:pichi-finance
pichi-finance は coingecko になかった
mexcを調べると pch は PigCoinHero っぽい?
とりあえず、そのまま "crypto/0xtorch-mexc-pch"
https://www.mexc.com/ja-JP/announcements/article/initial-listing-mexc-will-list-pigcoinhero-pch-in-innovation-zone-17827791516336

