### PR TITLE
Add Bitrue symbols

### DIFF
--- a/symbols/bitrue.json
+++ b/symbols/bitrue.json
@@ -1,0 +1,12 @@
+{
+  "BANANA": "crypto/apeswap-finance",
+  "BMAX": "crypto/bmax",
+  "BTR": "crypto/bitrue-token",
+  "MLD": "crypto/0xtorch-bitrue-mld",
+  "SGB": "crypto/songbird",
+  "USDP": "crypto/paxos-standard",
+  "USDT": "crypto/tether",
+  "VIBE": "crypto/0xtorch-bitrue-vibe",
+  "XDC": "crypto/xdce-crowd-sale",
+  "XLM": "crypto/stellar"
+}


### PR DESCRIPTION
対応が必要な CSV (bitrue-transaction-record) に登場する 10 シンボルを追加。

- for: 0xtorch/datasource-csv#239